### PR TITLE
Fix mandatory alarm code

### DIFF
--- a/custom_components/somfy_protexial/alarm_control_panel.py
+++ b/custom_components/somfy_protexial/alarm_control_panel.py
@@ -98,6 +98,11 @@ class ProtexialAlarm(CoordinatorEntity, AlarmControlPanelEntity):
             return CodeFormat.NUMBER
 
     @property
+    def code_arm_required(self) -> bool:
+        """Whether the code is required for arm actions."""
+        return self.arm_code is not None
+
+    @property
     def changed_by(self):
         """Return the last change triggered by."""
         return self._changed_by

--- a/custom_components/somfy_protexial/manifest.json
+++ b/custom_components/somfy_protexial/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/the8tre/somfy-protexial/issues",
   "loggers": ["custom_components.somfy_protexial"],
   "requirements": ["pyquery==2.0.0"],
-  "version": "1.2.0"
+  "version": "1.2.1"
 }


### PR DESCRIPTION
HA 2024.06 introduced a mandatory code on alarm_control_panel. Overridden code_arm_required method to provide the relevant value.
https://developers.home-assistant.io/blog/2024/05/22/alarm_control_panel_validation/

Fixes https://github.com/the8tre/somfy-protexial/issues/57